### PR TITLE
Rename MaterializableComponentMeta to ExpressibleByComponentMeta

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -86,7 +86,7 @@
 		041C7DFD4E40027278BABCCCD69743B2 /* ConstraintAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintAttributes.swift; path = Source/ConstraintAttributes.swift; sourceTree = "<group>"; };
 		0729DC38B02A17974FD7A7238FCB1836 /* ConstraintMultiplierTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMultiplierTarget.swift; path = Source/ConstraintMultiplierTarget.swift; sourceTree = "<group>"; };
 		0AB21FA0A2E5B45AB133215CC241236D /* UILayoutSupport+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UILayoutSupport+Extensions.swift"; path = "Source/UILayoutSupport+Extensions.swift"; sourceTree = "<group>"; };
-		1367C6F5311D05FDFBA37E96EE514019 /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SnapKit.framework; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1367C6F5311D05FDFBA37E96EE514019 /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14426FA5248A96FBC6A531879E24CFA5 /* SnapKit-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SnapKit-prefix.pch"; sourceTree = "<group>"; };
 		1CE616969B59014211F07875DEBE4D1A /* ComponentMeta.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComponentMeta.swift; sourceTree = "<group>"; };
 		1F2B728DCF7E9F88008827314C2AE823 /* ConstraintInsetTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintInsetTarget.swift; path = Source/ConstraintInsetTarget.swift; sourceTree = "<group>"; };
@@ -110,24 +110,24 @@
 		7BEA23F4393572EE30AED50A651CD185 /* ConstraintItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintItem.swift; path = Source/ConstraintItem.swift; sourceTree = "<group>"; };
 		813C2A5263E149C889A2DF40FFDD89BA /* ConstraintRelatableTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintRelatableTarget.swift; path = Source/ConstraintRelatableTarget.swift; sourceTree = "<group>"; };
 		857837F254F449F3BC19F608228401E0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		86396F85619BF19FD0D1DDD19B866116 /* TabBarCluster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBarCluster.swift; sourceTree = "<group>"; };
+		86396F85619BF19FD0D1DDD19B866116 /* TabBarCluster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabBarCluster.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8705AFD8FF18225FA8BB0228A69E72AA /* ConstraintMakerExtendable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMakerExtendable.swift; path = Source/ConstraintMakerExtendable.swift; sourceTree = "<group>"; };
 		87CCF4DB7EFBDC070B92BFC0BC0D2C8C /* ConstraintMakerRelatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMakerRelatable.swift; path = Source/ConstraintMakerRelatable.swift; sourceTree = "<group>"; };
 		8B78113584563565B18CD0248D9D0A93 /* ConstraintViewDSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintViewDSL.swift; path = Source/ConstraintViewDSL.swift; sourceTree = "<group>"; };
 		90B4839DF75CDC9F2CE552657CFE7D8E /* Component.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		97F0138AE8EA08984375344610BE7E1E /* ConstraintPriorityTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintPriorityTarget.swift; path = Source/ConstraintPriorityTarget.swift; sourceTree = "<group>"; };
-		996B2CFA945E1ECA2E39EFCC886C0D9E /* StackCluster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StackCluster.swift; sourceTree = "<group>"; };
+		996B2CFA945E1ECA2E39EFCC886C0D9E /* StackCluster.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StackCluster.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9F675DF8551ECAD72F0C6D96084C6DD4 /* SnapKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "SnapKit-dummy.m"; sourceTree = "<group>"; };
 		9F8ECEBD49CA569FC524CB77465180B6 /* ConstraintMakerEditable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMakerEditable.swift; path = Source/ConstraintMakerEditable.swift; sourceTree = "<group>"; };
-		A15769852F30012902C538DCBE3CDDF7 /* Matrioska.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Matrioska.framework; path = Matrioska.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A15769852F30012902C538DCBE3CDDF7 /* Matrioska.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Matrioska.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A77A10AC741F15F2412809F03C82B8FD /* Pods-MatrioskaExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-MatrioskaExample.debug.xcconfig"; sourceTree = "<group>"; };
 		AF1BDEFD46348EE8C41DE053AEDBFD1B /* ConstraintOffsetTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintOffsetTarget.swift; path = Source/ConstraintOffsetTarget.swift; sourceTree = "<group>"; };
-		B4E3E0231330567ABB197F1F0DA70261 /* Pods-MatrioskaExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-MatrioskaExample.modulemap"; sourceTree = "<group>"; };
+		B4E3E0231330567ABB197F1F0DA70261 /* Pods-MatrioskaExample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-MatrioskaExample.modulemap"; sourceTree = "<group>"; };
 		B525F7008B3760076D71FE29C0859BDC /* ConstraintLayoutGuide.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintLayoutGuide.swift; path = Source/ConstraintLayoutGuide.swift; sourceTree = "<group>"; };
 		B6EE3F460D1600FAF881B500AD8D239C /* Pods-MatrioskaExample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-MatrioskaExample-umbrella.h"; sourceTree = "<group>"; };
-		B7D4645BD3C0100FB7E1B4A6FDC96E0B /* SnapKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = SnapKit.modulemap; sourceTree = "<group>"; };
-		BBE9F7101D1F60A5A61A31D6CF1FEB9F /* Pods_MatrioskaExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_MatrioskaExample.framework; path = "Pods-MatrioskaExample.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B7D4645BD3C0100FB7E1B4A6FDC96E0B /* SnapKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SnapKit.modulemap; sourceTree = "<group>"; };
+		BBE9F7101D1F60A5A61A31D6CF1FEB9F /* Pods_MatrioskaExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MatrioskaExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BF2B524D7E160AA0C293D6D884CE4537 /* Pods-MatrioskaExample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-MatrioskaExample-acknowledgements.plist"; sourceTree = "<group>"; };
 		BF6FD1FF6B76CA2F5ED2E314D51E53CF /* Matrioska.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Matrioska.xcconfig; sourceTree = "<group>"; };
 		BF73CD5DB0A1A54717A1D51A96F5D7B9 /* UIColor+HEX.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIColor+HEX.swift"; sourceTree = "<group>"; };
@@ -139,7 +139,7 @@
 		CB70FEBA9EF66CAAA461E6F3F819716B /* ConstraintDescription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintDescription.swift; path = Source/ConstraintDescription.swift; sourceTree = "<group>"; };
 		CCA5B74A364868C16F69B955B38B05DD /* Pods-MatrioskaExample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-MatrioskaExample-acknowledgements.markdown"; sourceTree = "<group>"; };
 		CFE99A1044589BB7662A737268BCD6E7 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D59F8E5674A96129F9CF53C24D3B27BC /* Matrioska.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Matrioska.modulemap; sourceTree = "<group>"; };
+		D59F8E5674A96129F9CF53C24D3B27BC /* Matrioska.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Matrioska.modulemap; sourceTree = "<group>"; };
 		D61CFA974F0733418729D3C1AB335DFA /* Pods-MatrioskaExample-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-MatrioskaExample-frameworks.sh"; sourceTree = "<group>"; };
 		D8AA583273C076DD4A1EBAFDDA0E89A8 /* ConstraintMakerFinalizable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintMakerFinalizable.swift; path = Source/ConstraintMakerFinalizable.swift; sourceTree = "<group>"; };
 		E11295210FBB75091BE22529081A2720 /* ConstraintView+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ConstraintView+Extensions.swift"; path = "Source/ConstraintView+Extensions.swift"; sourceTree = "<group>"; };
@@ -227,7 +227,6 @@
 				0AB21FA0A2E5B45AB133215CC241236D /* UILayoutSupport+Extensions.swift */,
 				458932A7F6390E9028454F0A27A50A13 /* Support Files */,
 			);
-			name = SnapKit;
 			path = SnapKit;
 			sourceTree = "<group>";
 		};
@@ -256,7 +255,6 @@
 				8A1E1FBD297185C40000233E7909F3FB /* Helpers */,
 				D0642A2099E4BAF3C79FBF2A587950B7 /* Views */,
 			);
-			name = Source;
 			path = Source;
 			sourceTree = "<group>";
 		};
@@ -305,7 +303,6 @@
 			children = (
 				BF73CD5DB0A1A54717A1D51A96F5D7B9 /* UIColor+HEX.swift */,
 			);
-			name = Helpers;
 			path = Helpers;
 			sourceTree = "<group>";
 		};
@@ -353,7 +350,6 @@
 				FB9AD5B4352D254970FAAC4B20243037 /* IntrinsicSizeAwareScrollView.swift */,
 				77668395D8EFB67C5E715D53C2A08AEE /* StackViewController.swift */,
 			);
-			name = Views;
 			path = Views;
 			sourceTree = "<group>";
 		};

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Every `Component` may handle additional metadata. The `Component`’s meta is op
 #### ComponentMeta
 
 Every meta has to conform to `ComponentMeta`, a simple protocol that provides a keyed (String) subscript.  
-`ComponentMeta` provides a default implementation of a subscript that uses reflection (`Swift.Mirror`) to mirror the object and use its propertie's names and values. Objects that conform to this protocol can eventually override this behavior.  
+`ComponentMeta` provides a default implementation of a subscript that uses reflection (`Swift.Mirror`) to mirror the object and use its property's names and values. Objects that conform to this protocol can eventually override this behavior.  
 `ZipMeta`, for example, is a simple meta wrapper that aggregates multiple metas together; see its documentation and implementation for more info.
 `Dictionary` also conforms to `ComponentMeta`, this is a convenient way to provide meta but is especially useful to materialize a `ComponentMeta` coming from a json/dictionary.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   - [Standard Components](#standard-components)
   - [Meta](#meta)
     - [ComponentMeta](#componentmeta)
-    - [MaterializableComponentMeta](#materializablecomponentmeta)
+    - [ExpressibleByComponentMeta](#expressiblebycomponentMeta)
   - [Creating Components](#creating-components)
   - [Layout](#layout)
 - [Roadmap](#roadmap)
@@ -73,20 +73,20 @@ Every `Component` may handle additional metadata. The `Component`’s meta is op
 #### ComponentMeta
 
 Every meta has to conform to `ComponentMeta`, a simple protocol that provides a keyed (String) subscript.  
-`ComponentMeta` provides a default implementation of a subscript that uses reflection (`Swift.Mirror`) to mirror the object and use its properties names and values. Objects that conform to this protocol can eventually override this behavior.  
+`ComponentMeta` provides a default implementation of a subscript that uses reflection (`Swift.Mirror`) to mirror the object and use its propertie's names and values. Objects that conform to this protocol can eventually override this behavior.  
 `ZipMeta`, for example, is a simple meta wrapper that aggregates multiple metas together; see its documentation and implementation for more info.
 `Dictionary` also conforms to `ComponentMeta`, this is a convenient way to provide meta but is especially useful to materialize a `ComponentMeta` coming from a json/dictionary.
 
-#### MaterializableComponentMeta
+#### ExpressibleByComponentMeta
 
 When creating a new `Component` you should document which kind of meta it expects. A good way to do this is to also create an object that represents the `Component`’s meta (e.g. see `StackConfig`) and make it conform to `ComponentMeta`.  
-`MaterializableComponentMeta` however provides some convenience methods that let you load your components from a json or materialize a meta from a dictionary.  
-Other than `ComponentMeta`’s requirements you also need to provide a ` init?(meta: ComponentMeta)`, then you can materialize any compatible meta into your own `MaterializableComponentMeta`.  
+`ExpressibleByComponentMeta`, however, provides some convenience methods that lets you load your components from a json or materialize a meta from a dictionary; that is, it lets you express your meta configuration by any `ComponentMeta` object.  
+Other than `ComponentMeta`’s requirements you also need to provide a ` init?(meta: ComponentMeta)`, then you can materialize any compatible meta into your own `ExpressibleByComponentMeta`.  
 
 Example:
 
 ```swift
-public struct MyConfig: MaterializableComponentMeta {
+public struct MyConfig: ExpressibleByComponentMeta {
     public let title: String
     
     public init?(meta: ComponentMeta) {

--- a/Source/ComponentMeta.swift
+++ b/Source/ComponentMeta.swift
@@ -55,14 +55,14 @@ extension ComponentMeta {
 }
 
 /// A type that can be expressed by a `ComponentMeta` type.
-/// Adopting this protocol, `Component`s are able to materialize a ComponentMeta object
+/// Adopting this protocol, `Component`s are able to materialize a `ComponentMeta` object
 /// into this type using `ExpressibleByComponentMeta.materialize(_ )`.
 public protocol ExpressibleByComponentMeta: ComponentMeta {
     
-    /// An initializer that takes a ComponentMeta to retreive the necessary metadata
+    /// An initializer that takes a `ComponentMeta` to retreive the necessary metadata
     /// in order to build this object.
     /// `ExpressibleByComponentMeta.materialize(_ )` will then use this initializer, if necessary,
-    /// to create this object.
+    /// to create an object of this type.
     ///
     /// - Parameter meta: An object that conforms to `ComponentMeta`
     ///   and contains the desired metadata. A `Dictionary` can also be used.
@@ -75,7 +75,7 @@ extension ExpressibleByComponentMeta {
     ///
     /// - Parameter meta: A representation of the meta object to materialize (e.g. a dictionary)
     ///   or an already materialized meta object.
-    /// - Returns: A materialized ExpressibleByComponentMeta object if the input represents correctly
+    /// - Returns: A materialized `ExpressibleByComponentMeta` object if the input represents correctly
     ///   the object to be materialized. 
     /// - Note: This will return nil when `meta` is nil or will return the same `meta` object when `meta` is already a `Self` type.
     public static func materialize(_ meta: ComponentMeta?) -> Self? {

--- a/Source/ComponentMeta.swift
+++ b/Source/ComponentMeta.swift
@@ -54,30 +54,30 @@ extension ComponentMeta {
     }
 }
 
-/// A protocol to create `ComponentMeta` that also support json/dictionary for materialization.
-/// Adopting this protocol `Component`s are able to materialzie a meta
-/// using `MaterializableComponentMeta.materialize(_ )`.
-public protocol MaterializableComponentMeta: ComponentMeta {
+/// A type that can be expressed by a `ComponentMeta` type.
+/// Adopting this protocol, `Component`s are able to materialize a ComponentMeta object
+/// into this type using `ExpressibleByComponentMeta.materialize(_ )`.
+public protocol ExpressibleByComponentMeta: ComponentMeta {
     
-    /// An initializer that takes a meta to retreive the necessary metadata
-    /// to build the `ComponentMeta`.
-    /// `MaterializableComponentMeta.materialize(_ )` will then use this initializer, if necessary,
-    /// to create the meta object.
+    /// An initializer that takes a ComponentMeta to retreive the necessary metadata
+    /// in order to build this object.
+    /// `ExpressibleByComponentMeta.materialize(_ )` will then use this initializer, if necessary,
+    /// to create this object.
     ///
-    /// - Parameter meta: An object that conform to `ComponentMeta`
+    /// - Parameter meta: An object that conforms to `ComponentMeta`
     ///   and contains the desired metadata. A `Dictionary` can also be used.
     init?(meta: ComponentMeta)
 }
 
-extension MaterializableComponentMeta {
+extension ExpressibleByComponentMeta {
     
-    /// Materialize a meta into the meta object if possible (meta not nil)
-    /// and if needed (meta represents already a valid meta object of type `Self`)
+    /// Materializes a ComponentMeta into this type
     ///
     /// - Parameter meta: A representation of the meta object to materialize (e.g. a dictionary)
     ///   or an already materialized meta object.
-    /// - Returns: A materialized meta object if the input represents correctly
-    ///   the object to be materialized.
+    /// - Returns: A materialized ExpressibleByComponentMeta object if the input represents correctly
+    ///   the object to be materialized. 
+    /// - Note: This will return nil when `meta` is nil or will return the same `meta` object when `meta` is already a `Self` type.
     public static func materialize(_ meta: ComponentMeta?) -> Self? {
         guard let meta = meta else {
             return nil

--- a/Source/StackCluster.swift
+++ b/Source/StackCluster.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ClusterLayout {
     
     /// Stack component configuration.
-    public struct StackConfig: MaterializableComponentMeta {
+    public struct StackConfig: ExpressibleByComponentMeta {
         /// The title of the stack view, nil by default.
         public let title: String?
         /// The spacing of the components inside the stack. Default 10.

--- a/Source/TabBarCluster.swift
+++ b/Source/TabBarCluster.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ClusterLayout {
     
     /// Tab configuration.
-    public struct TabConfig: MaterializableComponentMeta {
+    public struct TabConfig: ExpressibleByComponentMeta {
         /// The tab title
         public let title: String
         /// The tab icon
@@ -49,7 +49,7 @@ extension ClusterLayout {
     }
     
     /// TabBar component configuration.
-    public struct TabBarConfig: MaterializableComponentMeta {
+    public struct TabBarConfig: ExpressibleByComponentMeta {
         /// The selected index of the tabBar. Not optional
         public let selectedIndex: Int
         

--- a/Tests/ComponentMetaTests.swift
+++ b/Tests/ComponentMetaTests.swift
@@ -112,7 +112,7 @@ class ComponentMetaTests: QuickSpec {
     }
 }
 
-public class DummyMeta: MaterializableComponentMeta {
+public class DummyMeta: ExpressibleByComponentMeta {
     public let property1: String?
     internal let property2: String
     fileprivate let property3: String


### PR DESCRIPTION
After checking the source code for `MaterializableComponentMeta` a couple of times, I had the feeling that it was somehow confusing to get his intention. Maybe this is just me, so I create this PR as a simple discussion to see if this type is more understandable with a renaming to `ExpressibleByComponentMeta` (also a more aligned name with Swift maybe) and with some tweaks on the documentation.

Please note that this is just a proposal and I am not against `MaterializableComponentMeta` 100%. It's just that I have the feeling that maybe is not that easy to understand it and I want to give it another thought.

If this is approved I would then update the missing documentation and README.

@MP0w @mathiasAichinger @AndreasThenn let me know what are your thoughts on this.