### PR TITLE
Refactoring/naming improvements

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,10 +17,11 @@ opt_in_rules:
 included:
   - Source
   - Tests
-  
+  - Example
+ 
 excluded:
   - Pods
-  - Example
+  - Example/Pods
 
 variable_name:
   excluded: # excluded via string array

--- a/Example/MatrioskaExample.xcodeproj/project.pbxproj
+++ b/Example/MatrioskaExample.xcodeproj/project.pbxproj
@@ -120,7 +120,6 @@
 				TargetAttributes = {
 					DE7C38651E005E3C00A399A3 = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = TPLF234WYY;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -328,7 +327,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = TPLF234WYY;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MatrioskaExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.runtastic.MatrioskaExample;
@@ -343,7 +342,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = TPLF234WYY;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MatrioskaExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.runtastic.MatrioskaExample;

--- a/Example/MatrioskaExample.xcodeproj/project.pbxproj
+++ b/Example/MatrioskaExample.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 				TargetAttributes = {
 					DE7C38651E005E3C00A399A3 = {
 						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = TPLF234WYY;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -327,6 +328,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = TPLF234WYY;
 				INFOPLIST_FILE = MatrioskaExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.runtastic.MatrioskaExample;
@@ -341,6 +343,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = TPLF234WYY;
 				INFOPLIST_FILE = MatrioskaExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.runtastic.MatrioskaExample;

--- a/Example/MatrioskaExample.xcodeproj/xcshareddata/xcschemes/MatrioskaExample.xcscheme
+++ b/Example/MatrioskaExample.xcodeproj/xcshareddata/xcschemes/MatrioskaExample.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DE7C38651E005E3C00A399A3"
+               BuildableName = "MatrioskaExample.app"
+               BlueprintName = "MatrioskaExample"
+               ReferencedContainer = "container:MatrioskaExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DE7C38651E005E3C00A399A3"
+            BuildableName = "MatrioskaExample.app"
+            BlueprintName = "MatrioskaExample"
+            ReferencedContainer = "container:MatrioskaExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DE7C38651E005E3C00A399A3"
+            BuildableName = "MatrioskaExample.app"
+            BlueprintName = "MatrioskaExample"
+            ReferencedContainer = "container:MatrioskaExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DE7C38651E005E3C00A399A3"
+            BuildableName = "MatrioskaExample.app"
+            BlueprintName = "MatrioskaExample"
+            ReferencedContainer = "container:MatrioskaExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/MatrioskaExample/AppDelegate.swift
+++ b/Example/MatrioskaExample/AppDelegate.swift
@@ -63,22 +63,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 private func navComponent(child: Component) -> Component {
-    let builder: Component.WrapperBuilder = { (child, meta) -> UIViewController? in
+    let builder: Component.WrapperViewBuilder = { (child, meta) -> UIViewController? in
         return child.viewController().map { UINavigationController(rootViewController: $0) }
     }
     
-    return Component.wrapper(builder: builder, child: child, meta: child.meta)
+    return Component.wrapper(viewBuilder: builder, child: child, meta: child.meta)
 }
 
 private func blankComponent(meta: ComponentMeta?) -> Component {
-    let builder: Component.ViewBuilder = { (meta) in
+    let builder: Component.SingleViewBuilder = { (meta) in
         let vc = UIViewController()
         vc.view.backgroundColor = .white
         return vc
     }
-    return Component.view(builder: builder, meta: meta)
+    return Component.single(viewBuilder: builder, meta: meta)
 }
 
 private func tileComponent(meta: TileConfig) -> Component {
-    return Component.view(builder: TileViewController.init(meta:), meta: meta)
+    return Component.single(viewBuilder: TileViewController.init(meta:), meta: meta)
 }

--- a/Example/MatrioskaExample/AppDelegate.swift
+++ b/Example/MatrioskaExample/AppDelegate.swift
@@ -63,20 +63,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 private func navComponent(child: Component) -> Component {
-    let builder: Component.WrapperViewBuilder = { (child, meta) -> UIViewController? in
+    let viewBuilder: Component.WrapperViewBuilder = { (child, meta) -> UIViewController? in
         return child.viewController().map { UINavigationController(rootViewController: $0) }
     }
     
-    return Component.wrapper(viewBuilder: builder, child: child, meta: child.meta)
+    return Component.wrapper(viewBuilder: viewBuilder, child: child, meta: child.meta)
 }
 
 private func blankComponent(meta: ComponentMeta?) -> Component {
-    let builder: Component.SingleViewBuilder = { (meta) in
+    let viewBuilder: Component.SingleViewBuilder = { (meta) in
         let vc = UIViewController()
         vc.view.backgroundColor = .white
         return vc
     }
-    return Component.single(viewBuilder: builder, meta: meta)
+    return Component.single(viewBuilder: viewBuilder, meta: meta)
 }
 
 private func tileComponent(meta: TileConfig) -> Component {

--- a/Example/MatrioskaExample/AppDelegate.swift
+++ b/Example/MatrioskaExample/AppDelegate.swift
@@ -32,12 +32,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                 tileComponent(meta: TileConfig(text: "A", color: .red)),
                                 tileComponent(meta: TileConfig(text: "B", color: .green)),
                                 tileComponent(meta: TileConfig(text: "C", color: .orange)),
-                                tileComponent(meta: TileConfig(text: "D", color: .yellow)),
+                                tileComponent(meta: TileConfig(text: "D", color: .yellow))
                                 ],
                             meta: ClusterLayout.StackConfig(axis: .horizontal)
                         ),
                         tileComponent(meta: TileConfig(text: "Three", color: .orange)),
-                        tileComponent(meta: TileConfig(text: "Four", color: .yellow)),
+                        tileComponent(meta: TileConfig(text: "Four", color: .yellow))
                     ],
                     meta: ZipMeta(ClusterLayout.TabConfig(title: "Third", iconName: "tabIcon"))
                 )
@@ -47,12 +47,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ),
             blankComponent(
                 meta: ClusterLayout.TabConfig(title: "Fifth", iconName: "tabIcon")
-            ),
+            )
         ],
         meta: ClusterLayout.TabBarConfig(selectedIndex: 2)
     )
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = rootComponent.viewController()

--- a/Example/MatrioskaExample/TileViewController.swift
+++ b/Example/MatrioskaExample/TileViewController.swift
@@ -15,7 +15,7 @@ struct TileConfig: ExpressibleByComponentMeta {
     
     init?(meta: ComponentMeta) {
         text = meta["text"] as? String
-        color = meta["color"] as? UIColor // TODO: in a json would probably we a string
+        color = meta["color"] as? UIColor
     }
     
     init(text: String?, color: UIColor) {

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ The vision of Matrioska is to let you build and prototype your app easily, reusi
 With Matrioska you can go as far as specifing the content and layout of your views from an external source (e.g. JSON).
 With this power you can easily change the structure of your app, do A/B testing, staged rollout or prototype.
 
-To build your UI you can use nested `Component`s. A `Component` can be 3 different things:
+Matrioska builds your UI from a `Component` tree. A `Component` can be one of:
 
-- **View**: Any `UIViewController` that can use AutoLayout to specify its `intrinsicContentSize`
-- **Cluster**: Views with children (other `Component`s). A cluster is responsible for laying out its children’s views. Since a cluster is itself a view it can also contain other clusters.
-- **Wrapper**: A View with only one child (a `Component`). You can see it as a special cluster or as a special view. It’s responsible for displaying its child’s view.
+- **Single**: A component whose view is any `UIViewController` that can express its `intrinsicContentSize` using AutoLayout. 
+- **Cluster**: A component that groups several children (other `Component`s). A cluster is responsible for laying out its children’s views. Since a cluster is itself a `Component`, clusters can be nested.
+- **Wrapper**: A component with only one child (another `Component`). You can see it as a special cluster, or as a decorator for a single component. It’s responsible for displaying its child’s view.
 - **Rule**: A `Component` which visibility is specified by a given `Rule`.
 
 The goal is to provide a tiny but powerful foundation to build your app on top of.
 Matrioska will contain a limited set of standard components and we will consider to add more on a case by case basis.  
-It’s really easy to extend Matrioska to add new components that fits your needs.
+It’s really easy to extend Matrioska to add new components that fit your needs.
 
 ## Installation
 
@@ -124,8 +124,8 @@ extension UITabBarController {
     }
 }
 
-// Any UIViewController can be used as a View
-// we can define a convenience init or just use an inline closure to build the ViewController
+// Any UIViewController can be used as a the view for a `Single` component. 
+// We can define a convenience initializer or just use an inline closure to build the ViewController
 class MyViewController: UIViewController {
     init(meta: Any?) {
         super.init(nibName: nil, bundle: nil)
@@ -138,9 +138,9 @@ class MyViewController: UIViewController {
 Then create models that can be easily used to create the entire tree of views:
 
 ```swift
-let component = Component.cluster(builder: UITabBarController.init, children: [
-    Component.view(builder: MyViewController.init, meta: ["title": "tab1"]),
-    Component.view(builder: { _ in UIViewController() }, meta: nil),
+let component = Component.cluster(viewBuilder: UITabBarController.init, children: [
+    Component.single(viewBuilder: MyViewController.init, meta: ["title": "tab1"]),
+    Component.single(viewBuilder: { _ in UIViewController() }, meta: nil),
     ], meta: nil)
 
 window.rootViewController = component.viewController()
@@ -175,38 +175,40 @@ The `Rule`'s meta will be their `Component`'s meta.
 
 ### Load Components from JSON
 
-`Components` can also be loaded from JSON. For this, you are responsible for registering factories (`Component` builders) that will be used when parsing the JSON structure. In order to register factories, usage of `JSONFactory` is needed:
+`Components` can also be loaded from JSON. For this, you are responsible for registering `Component` builders that will be used when parsing the JSON structure. 
+
+Here's how to register component builders on a `JSONFactory`:
 
 ```
 let jsonFactory = JSONFactory()
 
-jsonFactory.register(with: "tab_bar", factoryBuilder: { (children, meta) in
+jsonFactory.register(builder: { (children, meta) in
     ClusterLayout.tabBar(children: children, meta: meta)
-})
+}, forType: "tab_bar")
 
-jsonFactory.register(with: "navigation", factoryBuilder: { (child, meta) in
-    Component.wrapper(builder: { _ in UINavigationController() }, child: child, meta: meta)
-})
+jsonFactory.register(builder: { (child, meta) in
+    Component.wrapper(viewBuilder: { _ in UINavigationController() }, child: child, meta: meta)
+}, forType: "navigation")
 
-jsonFactory.register(with: "table_view", factoryBuilder: { (meta) in
-    Component.view(builder: { _ in UITableViewController() }, meta: meta)
-})
+jsonFactory.register(builder: { (meta) in
+    Component.single(viewBuilder: { _ in UITableViewController() }, meta: meta)
+}, forType: "table_view")
 
-jsonFactory.register(with: "is_male", factoryBuilder: { () in
-  return User.isMale
-})
+jsonFactory.register(builder: { () in
+    return User.isMale
+}, forType: "is_male")
 
-jsonFactory.register(with: "is_gold_member", factoryBuilder: { () in
-  return User.isGoldMember
-})
+jsonFactory.register(builder: { () in
+    return User.isGoldMember
+}, forType: "is_gold_member")
 ```
 
-Whenever you register a new factory you should provide the `type` key that will match the JSON. Check the [provided JSON schema](/Documentation/JSON\ schema\ guide.md) for more details on that.
+Whenever you register a new component builder you should provide the `type` key that will match the JSON. Check the [provided JSON schema](/Documentation/JSON\ schema\ guide.md) for more details on that.
 
-You can register different factories for `View`, `Wrapper`, `Cluster` and  `Rule` `Component` types using the `JSONFactory`. After registration, you can use the factory to get the component out of a JSON:
+You can register different component builders for `Single`, `Wrapper`, `Cluster` and  `Rule` `Component` types using the `JSONFactory`. After registration, you can use the factory to get the root component from a JSON:
 
 ```
-let component = try jsonFactory.component(from: json)
+return try jsonFactory.makeComponent(json: json)
 ```
 
 `Component`s, `Meta`s and `Rule`s should also match the JSON schema that the library provides by default.
@@ -222,4 +224,5 @@ Check the [JSON schema guide](/Documentation/JSON\ schema\ guide.md) for more in
 ## License
 
 Matrioska is released under the MIT License.  
-At Runtastic we don't keep an internal mirror of this repo and all development on Matrioska is done in the open.
+
+At Runtastic we don't keep an internal mirror of this repo. All development on Matrioska is done in the open.

--- a/Source/Components/Component.swift
+++ b/Source/Components/Component.swift
@@ -9,25 +9,26 @@
 import Foundation
 
 /// Represents a UI `Component`
-/// `Component`s can be nested and contain other components
+/// `Component`s can be nested and contain other components.
 public indirect enum Component {
 
-    /// A closure to build a `UIViewController`. Can receive metadata for additional configuration.
+    /// A closure to build a `UIViewController` for a single component.
+    /// Can receive metadata for additional configuration.
     public typealias SingleViewBuilder = (_ meta: ComponentMeta?) -> UIViewController?
     
-    /// A closure to build a wrapper `UIViewController`.
+    /// A closure to build a `UIViewController` for a wrapper component.
     /// The view is responsible to wrap and display it's child component.
-    /// Can receive metadata 
+    /// Can receive metadata for additional configuration.
     public typealias WrapperViewBuilder = (
         _ child: Component,
         _ meta: ComponentMeta?
         ) -> UIViewController?
     
-    /// A closure to build a cluster `UIViewController`.
+    /// A closure to build a `UIViewController` for a cluster component.
     /// The builder can return nil in case the `Component` shouldn't be shown.
     /// For example a `Component` that lacks proper metadata might not be displayable.
     /// The view is responsible to display and layout its children components.
-    /// Can receive metadata for additional configuration..
+    /// Can receive metadata for additional configuration.
     public typealias ClusterViewBuilder = (
         _ children: [Component],
         _ meta: ComponentMeta?

--- a/Source/Components/Component.swift
+++ b/Source/Components/Component.swift
@@ -12,45 +12,47 @@ import Foundation
 /// `Component`s can be nested and contain other components
 public indirect enum Component {
 
-    /// A closure to build a ViewController. Can receive metadata for additional configurations
-    public typealias ViewBuilder = (_ meta: ComponentMeta?) -> UIViewController?
-    /// A closure to build a Wrapper ViewController.
+    /// A closure to build a `UIViewController`. Can receive metadata for additional configuration.
+    public typealias SingleViewBuilder = (_ meta: ComponentMeta?) -> UIViewController?
+    
+    /// A closure to build a wrapper `UIViewController`.
     /// The view is responsible to wrap and display it's child component.
-    /// Can receive metadata for additional configurations
-    public typealias WrapperBuilder = (
+    /// Can receive metadata 
+    public typealias WrapperViewBuilder = (
         _ child: Component,
         _ meta: ComponentMeta?
         ) -> UIViewController?
-    /// A closure to build a Cluster ViewController.
+    
+    /// A closure to build a cluster `UIViewController`.
     /// The builder can return nil in case the `Component` shouldn't be shown.
     /// For example a `Component` that lacks proper metadata might not be displayable.
     /// The view is responsible to display and layout its children components.
-    /// Can receive metadata for additional configurations
-    public typealias ClusterBuilder = (
+    /// Can receive metadata for additional configuration..
+    public typealias ClusterViewBuilder = (
         _ children: [Component],
         _ meta: ComponentMeta?
         ) -> UIViewController?
 
     /// Represents any `UIViewController`.
     /// The view should use AutoLayout to specify its `intrinsicContentSize`.
-    case view(builder: ViewBuilder, meta: ComponentMeta?)
-    /// Represents a view with only one child (a `Component`).
+    case single(viewBuilder: SingleViewBuilder, meta: ComponentMeta?)
+    /// Represents a view with only one child (another `Component`).
     /// The view should use AutoLayout to specify its `intrinsicContentSize`.
     /// You can see it as a special cluster or as a special view.
     /// It’s responsible to display its child’s view.
-    case wrapper(builder: WrapperBuilder, child: Component, meta: ComponentMeta?)
+    case wrapper(viewBuilder: WrapperViewBuilder, child: Component, meta: ComponentMeta?)
     /// Represents a view with children (other `Component`s).
     /// A cluster is responsible of laying out its children’s views.
     /// Since a cluster is itself a view it can also contain other clusters.
-    case cluster(builder: ClusterBuilder, children: [Component], meta: ComponentMeta?)
-    /// Represents a Component which visibility is specified 
-    /// by the evaluation of a `Rule`
+    case cluster(viewBuilder: ClusterViewBuilder, children: [Component], meta: ComponentMeta?)
+    /// Represents a Component whose visibility is specified
+    /// by the evaluation of a `Rule`.
     case rule(rule: Rule, component: Component)
 
     /// The meta of the component
     public var meta: ComponentMeta? {
         switch self {
-        case let .view(_, meta):
+        case let .single(_, meta):
             return meta
         case let .wrapper(_, _, meta):
             return meta
@@ -63,13 +65,13 @@ public indirect enum Component {
     
     /// Create a ViewController represented by the `Component`
     ///
-    /// - Returns: An optional UIViewController.
+    /// - Returns: An optional `UIViewController`.
     /// The receiver is responsible to handle eventual fallbacks.
     /// The builder can return nil in case the `Component` shouldn't be shown.
     /// For example a `Component` that lacks proper metadata might not be displayable.
     public func viewController() -> UIViewController? {
         switch self {
-        case let .view(builder, meta):
+        case let .single(builder, meta):
             return builder(meta)
         case let .wrapper(builder, child, meta):
             return builder(child, meta)

--- a/Source/Components/StackCluster.swift
+++ b/Source/Components/StackCluster.swift
@@ -79,7 +79,7 @@ extension ClusterLayout {
     ///   - meta: Should represent `StackConfig` object to configure the stack view
     /// - Returns: A stack component
     public static func stack(children: [Component], meta: ComponentMeta?) -> Component {
-        return Component.cluster(builder: stackBuilder,
+        return Component.cluster(viewBuilder: stackBuilder,
                                  children: children,
                                  meta: meta)
     }

--- a/Source/Components/TabBarCluster.swift
+++ b/Source/Components/TabBarCluster.swift
@@ -85,14 +85,14 @@ extension ClusterLayout {
                               meta: ComponentMeta?,
                               bundle: Bundle? = nil) -> Component {
         
-        return Component.cluster(builder: tabBarBuilder(bundle),
+        return Component.cluster(viewBuilder: tabBarViewBuilder(bundle),
                                  children: children,
                                  meta: meta)
     }
     
     /// A builder for tabBar component that uses partial application
     /// to let us specify the bundle where the images of tabBar items are located
-    private static func tabBarBuilder(_ bundle: Bundle?) -> Component.ClusterBuilder {
+    private static func tabBarViewBuilder(_ bundle: Bundle?) -> Component.ClusterViewBuilder {
         
         typealias Tab = (meta: TabConfig, viewController: UIViewController)
 

--- a/Source/Factories/JSONFactory.swift
+++ b/Source/Factories/JSONFactory.swift
@@ -39,16 +39,16 @@ fileprivate enum RuleKey {
 /// `ClusterBuilder` & `RuleBuilder`) and uses them to produce `Component`s
 public final class JSONFactory {
     
-    /// A closure to build a .single `Component`
+    /// A closure to build a single `Component`
     public typealias SingleBuilder = (ComponentMeta?) -> Component
     
-    /// A closure to build a .wrapper `Component`
+    /// A closure to build a wrapper `Component`
     public typealias WrapperBuilder = (Component, ComponentMeta?) -> Component
     
-    /// A closure to build a .cluster `Component`
+    /// A closure to build a cluster `Component`
     public typealias ClusterBuilder = ([Component], ComponentMeta?) -> Component
     
-    /// A closure to build a .rule `Component`
+    /// A closure to build a rule `Component`
     public typealias RuleBuilder = Rule.RuleEvaluator
     
     fileprivate var singleBuilders: [String: SingleBuilder] = [:]
@@ -64,8 +64,8 @@ public final class JSONFactory {
     /// Registers a new `SingleBuilder` which will be used when producing the component
     ///
     /// - Parameters:
-    ///   - type: a string identifying this factory type
-    ///   - builder: a `SingleBuilder` to build a `Component`
+    ///   - type: a string identifying the component type
+    ///   - builder: a `SingleBuilder` for the given type
     public func register(builder: @escaping SingleBuilder, forType type: String) {
         singleBuilders[type] = builder
     }
@@ -73,8 +73,8 @@ public final class JSONFactory {
     /// Registers a new `WrapperBuilder` which will be used when producing the component
     ///
     /// - Parameters:
-    ///   - type: a string identifying this factory type
-    ///   - builder: a `WrapperBuilder` to build a `Component`
+    ///   - type: a string identifying the component type
+    ///   - builder: a `WrapperBuilder` for the given type
     public func register(builder: @escaping WrapperBuilder, forType type: String) {
         wrapperBuilders[type] = builder
     }
@@ -82,8 +82,8 @@ public final class JSONFactory {
     /// Registers a new `ClusterBuilder` which will be used when producing the component
     ///
     /// - Parameters:
-    ///   - type: a string identifying this factory type
-    ///   - builder: a `ClusterBuilder` to build a `Component`
+    ///   - type: a string identifying the component type
+    ///   - builder: a `ClusterBuilder` for the given type
     public func register(builder: @escaping ClusterBuilder, forType type: String) {
         clusterBuilders[type] = builder
     }
@@ -91,8 +91,8 @@ public final class JSONFactory {
     /// Registers a new `RuleBuilder` which will be used when producing the component
     ///
     /// - Parameters:
-    ///   - type: a string identifying this factory type
-    ///   - builder: a `RuleBuilder` to build a `Component`
+    ///   - type: a string identifying the component type
+    ///   - builder: a `RuleBuilder` for the given type
     public func register(builder: @escaping RuleBuilder, forType type: String) {
         ruleBuilders[type] = builder
     }
@@ -135,13 +135,13 @@ extension JSONFactory {
     fileprivate func makeComponent(type: String, meta: JSONObject?, children: [Component]) -> Component? {
         var component: Component? = nil
         
-        if let standaloneFactory = singleBuilders[type] {
-            component = standaloneFactory(meta)
-        } else if let wrapperFactory = wrapperBuilders[type],
-            let componentChild = children.first {
-            component = wrapperFactory(componentChild, meta)
-        } else if let clusterFactory = clusterBuilders[type] {
-            component = clusterFactory(children, meta)
+        if let singleBuilder = singleBuilders[type] {
+            component = singleBuilder(meta)
+        } else if let wrapperBuilder = wrapperBuilders[type],
+            let child = children.first {
+            component = wrapperBuilder(child, meta)
+        } else if let clusterBuilder = clusterBuilders[type] {
+            component = clusterBuilder(children, meta)
         }
         
         return component
@@ -164,10 +164,10 @@ extension JSONFactory {
 extension String {
     
     fileprivate func makeRule(builders: [String: JSONFactory.RuleBuilder]) -> Rule? {
-        guard let ruleFactory = builders[self] else {
+        guard let ruleBuilder = builders[self] else {
             return nil
         }
-        return Rule.simple(evaluator: ruleFactory)
+        return Rule.simple(evaluator: ruleBuilder)
     }
 }
 

--- a/Tests/ComponentTests.swift
+++ b/Tests/ComponentTests.swift
@@ -19,13 +19,13 @@ class ComponentTests: QuickSpec {
         
         describe("View component") {
             it("should build a viewController") {
-                let component = Component.view(builder: { _ in UIViewController() }, meta: nil)
+                let component = Component.single(viewBuilder: { _ in UIViewController() }, meta: nil)
                 expect(component.viewController()).toNot(beNil())
             }
             
             it("should pass metadata to the builder") {
                 var value: ComponentMeta? = nil
-                _ = Component.view(builder: { (meta) in
+                _ = Component.single(viewBuilder: { (meta) in
                     value = meta
                     return UIViewController()
                 }, meta: ["foo": "bar"]).viewController()
@@ -34,8 +34,8 @@ class ComponentTests: QuickSpec {
             }
             
             it("should have the correct metadata") {
-                let component = Component.view(builder: { _ in UIViewController() },
-                                               meta: ["foo": "bar"])
+                let component = Component.single(viewBuilder: { _ in UIViewController() },
+                                                 meta: ["foo": "bar"])
                 
                 expect(component.meta as? DictMeta) == ["foo": "bar"]
             }
@@ -43,7 +43,7 @@ class ComponentTests: QuickSpec {
         
         describe("Wrapper component") {
             it("should build a viewController") {
-                let component = Component.wrapper(builder: { _ in UIViewController() },
+                let component = Component.wrapper(viewBuilder: { _ in UIViewController() },
                                                   child: randComponent(),
                                                   meta: nil)
                 expect(component.viewController()).toNot(beNil())
@@ -51,12 +51,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass the child to the builder") {
                 var component: Component? = nil
-                let builder: Component.WrapperBuilder = { (child, _) in
+                let builder: Component.WrapperViewBuilder = { (child, _) in
                     component = child
                     return UIViewController()
                 }
                 
-                _ =  Component.wrapper(builder: builder,
+                _ =  Component.wrapper(viewBuilder: builder,
                                        child: randComponent(),
                                        meta: nil).viewController()
                 
@@ -65,12 +65,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass metadata to the builder") {
                 var value: ComponentMeta? = nil
-                let builder: Component.WrapperBuilder = { (_, meta) in
+                let builder: Component.WrapperViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
                 
-                _ =  Component.wrapper(builder: builder,
+                _ =  Component.wrapper(viewBuilder: builder,
                                        child: randComponent(),
                                        meta: ["foo": "bar"]).viewController()
                 
@@ -78,9 +78,9 @@ class ComponentTests: QuickSpec {
             }
             
             it("should have the correct metadata") {
-                let component =  Component.wrapper(builder: { _ in UIViewController() },
-                                       child: randComponent(),
-                                       meta: ["foo": "bar"])
+                let component =  Component.wrapper(viewBuilder: { _ in UIViewController() },
+                                                   child: randComponent(),
+                                                   meta: ["foo": "bar"])
                 
                 expect(component.meta as? DictMeta) == ["foo": "bar"]
             }
@@ -88,7 +88,7 @@ class ComponentTests: QuickSpec {
         
         describe("Cluster component") {
             it("should build a viewController") {
-                let component = Component.cluster(builder: { _ in UIViewController() },
+                let component = Component.cluster(viewBuilder: { _ in UIViewController() },
                                                   children: [randComponent()],
                                                   meta: nil)
                 expect(component.viewController()).toNot(beNil())
@@ -96,12 +96,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass the children to the builder") {
                 var components: [Component]? = nil
-                let builder: Component.ClusterBuilder = { (children, _) in
+                let builder: Component.ClusterViewBuilder = { (children, _) in
                     components = children
                     return UIViewController()
                 }
                 
-                _ =  Component.cluster(builder: builder,
+                _ =  Component.cluster(viewBuilder: builder,
                                        children: [randComponent()],
                                        meta: nil).viewController()
                 
@@ -110,12 +110,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass metadata to the builder") {
                 var value: ComponentMeta? = nil
-                let builder: Component.ClusterBuilder = { (_, meta) in
+                let builder: Component.ClusterViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
                 
-                _ =  Component.cluster(builder: builder,
+                _ =  Component.cluster(viewBuilder: builder,
                                        children: [randComponent()],
                                        meta: ["foo": "bar"]).viewController()
                 
@@ -123,7 +123,7 @@ class ComponentTests: QuickSpec {
             }
             
             it("should have the correct metadata") {
-                let component =  Component.cluster(builder: { _ in UIViewController() },
+                let component =  Component.cluster(viewBuilder: { _ in UIViewController() },
                                                    children: [randComponent()],
                                                    meta: ["foo": "bar"])
                 
@@ -133,7 +133,7 @@ class ComponentTests: QuickSpec {
         
         describe("Rule component") {
             it("builds his child view controller if it evaluates to true") {
-                let cluster = Component.cluster(builder: { _ in UIViewController() },
+                let cluster = Component.cluster(viewBuilder: { _ in UIViewController() },
                                                 children: [randComponent()],
                                                 meta: nil)
                 let rule = Rule.not(rule: Rule.simple(evaluator: { false }))
@@ -142,7 +142,7 @@ class ComponentTests: QuickSpec {
             }
             
             it("does not build his child view controller if it evaluates to false") {
-                let cluster = Component.cluster(builder: { _ in UIViewController() },
+                let cluster = Component.cluster(viewBuilder: { _ in UIViewController() },
                                                 children: [randComponent()],
                                                 meta: nil)
                 let rule = Rule.and(rules: [Rule.simple(evaluator: { false }), Rule.simple(evaluator: { true })])
@@ -153,11 +153,11 @@ class ComponentTests: QuickSpec {
             it("passes the children to the child's builder if it evaluates to true") {
                 let rule = Rule.or(rules: [Rule.simple(evaluator: { false }), Rule.simple(evaluator: { true })])
                 var components: [Component]? = nil
-                let builder: Component.ClusterBuilder = { (children, _) in
+                let builder: Component.ClusterViewBuilder = { (children, _) in
                     components = children
                     return UIViewController()
                 }
-                let cluster = Component.cluster(builder: builder,
+                let cluster = Component.cluster(viewBuilder: builder,
                                                 children: [randComponent()],
                                                 meta: nil)
                 
@@ -169,11 +169,11 @@ class ComponentTests: QuickSpec {
             it("does not pass the children to the child's builder if it evaluates to false") {
                 let rule = Rule.not(rule: Rule.simple(evaluator: { true }))
                 var components: [Component]? = nil
-                let builder: Component.ClusterBuilder = { (children, _) in
+                let builder: Component.ClusterViewBuilder = { (children, _) in
                     components = children
                     return UIViewController()
                 }
-                let cluster = Component.cluster(builder: builder,
+                let cluster = Component.cluster(viewBuilder: builder,
                                                 children: [randComponent()],
                                                 meta: nil)
                 
@@ -185,11 +185,11 @@ class ComponentTests: QuickSpec {
             it("passes metadata to the child's builder if it evaluates to true") {
                 let rule = Rule.not(rule: Rule.simple(evaluator: { false }))
                 var value: ComponentMeta? = nil
-                let builder: Component.ClusterBuilder = { (_, meta) in
+                let builder: Component.ClusterViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
-                let cluster = Component.cluster(builder: builder,
+                let cluster = Component.cluster(viewBuilder: builder,
                                                 children: [randComponent()],
                                                 meta: ["foo": "bar"])
                 
@@ -201,11 +201,11 @@ class ComponentTests: QuickSpec {
             it("does not pass metadata to the child's builder if it evaluates to false") {
                 let rule = Rule.simple(evaluator: { false })
                 var value: ComponentMeta? = nil
-                let builder: Component.ClusterBuilder = { (_, meta) in
+                let builder: Component.ClusterViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
-                let cluster = Component.cluster(builder: builder,
+                let cluster = Component.cluster(viewBuilder: builder,
                                                 children: [randComponent()],
                                                 meta: ["one": "two"])
                 
@@ -216,9 +216,9 @@ class ComponentTests: QuickSpec {
             
             it("has the correct child's metadata regardless of evaluating to true/false") {
                 let rule = Rule.simple(evaluator: { false })
-                let cluster =  Component.cluster(builder: { _ in UIViewController() },
-                                                   children: [randComponent()],
-                                                   meta: ["foo": "bar"])
+                let cluster =  Component.cluster(viewBuilder: { _ in UIViewController() },
+                                                 children: [randComponent()],
+                                                 meta: ["foo": "bar"])
                 let falseComponent = Component.rule(rule: rule, component: cluster)
                 let trueComponent = Component.rule(rule: Rule.not(rule: rule), component: cluster)
                 
@@ -230,5 +230,5 @@ class ComponentTests: QuickSpec {
 }
 
 private func randComponent() -> Component {
-    return  Component.view(builder: { _ in UIViewController() }, meta: nil)
+    return  Component.single(viewBuilder: { _ in UIViewController() }, meta: nil)
 }

--- a/Tests/ComponentTests.swift
+++ b/Tests/ComponentTests.swift
@@ -51,12 +51,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass the child to the builder") {
                 var component: Component? = nil
-                let builder: Component.WrapperViewBuilder = { (child, _) in
+                let viewBuilder: Component.WrapperViewBuilder = { (child, _) in
                     component = child
                     return UIViewController()
                 }
                 
-                _ =  Component.wrapper(viewBuilder: builder,
+                _ =  Component.wrapper(viewBuilder: viewBuilder,
                                        child: randComponent(),
                                        meta: nil).viewController()
                 
@@ -65,12 +65,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass metadata to the builder") {
                 var value: ComponentMeta? = nil
-                let builder: Component.WrapperViewBuilder = { (_, meta) in
+                let viewBuilder: Component.WrapperViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
                 
-                _ =  Component.wrapper(viewBuilder: builder,
+                _ =  Component.wrapper(viewBuilder: viewBuilder,
                                        child: randComponent(),
                                        meta: ["foo": "bar"]).viewController()
                 
@@ -96,12 +96,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass the children to the builder") {
                 var components: [Component]? = nil
-                let builder: Component.ClusterViewBuilder = { (children, _) in
+                let viewBuilder: Component.ClusterViewBuilder = { (children, _) in
                     components = children
                     return UIViewController()
                 }
                 
-                _ =  Component.cluster(viewBuilder: builder,
+                _ =  Component.cluster(viewBuilder: viewBuilder,
                                        children: [randComponent()],
                                        meta: nil).viewController()
                 
@@ -110,12 +110,12 @@ class ComponentTests: QuickSpec {
             
             it("should pass metadata to the builder") {
                 var value: ComponentMeta? = nil
-                let builder: Component.ClusterViewBuilder = { (_, meta) in
+                let viewBuilder: Component.ClusterViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
                 
-                _ =  Component.cluster(viewBuilder: builder,
+                _ =  Component.cluster(viewBuilder: viewBuilder,
                                        children: [randComponent()],
                                        meta: ["foo": "bar"]).viewController()
                 
@@ -153,11 +153,11 @@ class ComponentTests: QuickSpec {
             it("passes the children to the child's builder if it evaluates to true") {
                 let rule = Rule.or(rules: [Rule.simple(evaluator: { false }), Rule.simple(evaluator: { true })])
                 var components: [Component]? = nil
-                let builder: Component.ClusterViewBuilder = { (children, _) in
+                let viewBuilder: Component.ClusterViewBuilder = { (children, _) in
                     components = children
                     return UIViewController()
                 }
-                let cluster = Component.cluster(viewBuilder: builder,
+                let cluster = Component.cluster(viewBuilder: viewBuilder,
                                                 children: [randComponent()],
                                                 meta: nil)
                 
@@ -169,11 +169,11 @@ class ComponentTests: QuickSpec {
             it("does not pass the children to the child's builder if it evaluates to false") {
                 let rule = Rule.not(rule: Rule.simple(evaluator: { true }))
                 var components: [Component]? = nil
-                let builder: Component.ClusterViewBuilder = { (children, _) in
+                let viewBuilder: Component.ClusterViewBuilder = { (children, _) in
                     components = children
                     return UIViewController()
                 }
-                let cluster = Component.cluster(viewBuilder: builder,
+                let cluster = Component.cluster(viewBuilder: viewBuilder,
                                                 children: [randComponent()],
                                                 meta: nil)
                 
@@ -185,11 +185,11 @@ class ComponentTests: QuickSpec {
             it("passes metadata to the child's builder if it evaluates to true") {
                 let rule = Rule.not(rule: Rule.simple(evaluator: { false }))
                 var value: ComponentMeta? = nil
-                let builder: Component.ClusterViewBuilder = { (_, meta) in
+                let viewBuilder: Component.ClusterViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
-                let cluster = Component.cluster(viewBuilder: builder,
+                let cluster = Component.cluster(viewBuilder: viewBuilder,
                                                 children: [randComponent()],
                                                 meta: ["foo": "bar"])
                 
@@ -201,11 +201,11 @@ class ComponentTests: QuickSpec {
             it("does not pass metadata to the child's builder if it evaluates to false") {
                 let rule = Rule.simple(evaluator: { false })
                 var value: ComponentMeta? = nil
-                let builder: Component.ClusterViewBuilder = { (_, meta) in
+                let viewBuilder: Component.ClusterViewBuilder = { (_, meta) in
                     value = meta
                     return UIViewController()
                 }
-                let cluster = Component.cluster(viewBuilder: builder,
+                let cluster = Component.cluster(viewBuilder: viewBuilder,
                                                 children: [randComponent()],
                                                 meta: ["one": "two"])
                 

--- a/Tests/JSONFactoryTests.swift
+++ b/Tests/JSONFactoryTests.swift
@@ -33,7 +33,7 @@ class JSONFactoryTests: QuickSpec {
         
         let json = try! JSONReader.jsonObject(from: jsonFileName, bundle: bundle)!
         
-        let viewBuilder: JSONFactory.SingleBuilder = { (meta: ComponentMeta?) in
+        let singleBuilder: JSONFactory.SingleBuilder = { (meta: ComponentMeta?) in
             Component.single(viewBuilder: { _ in UIViewController() }, meta: meta)
         }
         let tabBarBuilder: JSONFactory.ClusterBuilder = { (children, meta) in
@@ -118,9 +118,9 @@ class JSONFactoryTests: QuickSpec {
                 jsonFactory.register(builder: tabBarBuilder, forType: "tabbar")
                 jsonFactory.register(builder: stackBuilder, forType: "stack")
                 jsonFactory.register(builder: navigationBuilder, forType: "navigation")
-                jsonFactory.register(builder: viewBuilder, forType: "button")
-                jsonFactory.register(builder: viewBuilder, forType: "label")
-                jsonFactory.register(builder: viewBuilder, forType: "table_view")
+                jsonFactory.register(builder: singleBuilder, forType: "button")
+                jsonFactory.register(builder: singleBuilder, forType: "label")
+                jsonFactory.register(builder: singleBuilder, forType: "table_view")
                 
                 let component = try! jsonFactory.makeComponent(json: json)
                 
@@ -167,9 +167,9 @@ class JSONFactoryTests: QuickSpec {
                 jsonFactory.register(builder: tabBarBuilder, forType: "tabbar")
                 jsonFactory.register(builder: stackBuilder, forType: "stack")
                 jsonFactory.register(builder: navigationBuilder, forType: "navigation")
-                jsonFactory.register(builder: viewBuilder, forType: "button")
-                jsonFactory.register(builder: viewBuilder, forType: "label")
-                jsonFactory.register(builder: viewBuilder, forType: "table_view")
+                jsonFactory.register(builder: singleBuilder, forType: "button")
+                jsonFactory.register(builder: singleBuilder, forType: "label")
+                jsonFactory.register(builder: singleBuilder, forType: "table_view")
                 jsonFactory.register(builder: falseRuleBuilder, forType: "is_male")
                 jsonFactory.register(builder: trueRuleBuilder, forType: "is_gold_member")
                 

--- a/Tests/StackClusterTests.swift
+++ b/Tests/StackClusterTests.swift
@@ -286,7 +286,7 @@ private func labelComponent(title: String?,
                             color: UIColor? = nil,
                             labelSize: CGSize? = nil) -> Component {
     
-    let builder: Component.SingleViewBuilder = { meta in
+    let viewBuilder: Component.SingleViewBuilder = { meta in
         let vc = UIViewController()
         vc.view.backgroundColor = color
         let label = UILabel()
@@ -304,7 +304,7 @@ private func labelComponent(title: String?,
     }
     
     return Component.single(
-        viewBuilder: builder,
+        viewBuilder: viewBuilder,
         meta: title.map { ["title": $0] }
     )
 }

--- a/Tests/StackClusterTests.swift
+++ b/Tests/StackClusterTests.swift
@@ -23,7 +23,7 @@ class StackClusterTests: QuickSpec {
                 labelComponent(title: "first", color: .red),
                 labelComponent(title: "second", color: .blue),
                 labelComponent(title: "third\ntwo lines", color: .orange)
-                ]
+            ]
             
             it("should display its child and respect their intrinsic contentSize") {
                 let vc = stack(with: children)
@@ -33,10 +33,10 @@ class StackClusterTests: QuickSpec {
             it("should not display childs that don't have a view") {
                 let children = [
                     labelComponent(title: "first", color: .red),
-                    Component.view(builder: { _ in nil }, meta: nil),
+                    Component.single(viewBuilder: { _ in nil }, meta: nil),
                     labelComponent(title: "second", color: .orange),
-                    Component.view(builder: { _ in nil }, meta: nil)
-                    ]
+                    Component.single(viewBuilder: { _ in nil }, meta: nil)
+                ]
                 let vc = stack(with: children)
                 expect(vc).to(haveValidSnapshot())
                 expect(vc?.stackView.arrangedSubviews).to(haveCount(2))
@@ -47,7 +47,7 @@ class StackClusterTests: QuickSpec {
                     let children = [
                         labelComponent(title: "first", color: .yellow),
                         labelComponent(title: "second", color: .green)
-                        ]
+                    ]
                     let vc = stack(with: children, meta: ["foo": "bar"])
                     expect(vc).to(haveValidSnapshot())
                     let defaultConfig = ClusterLayout.StackConfig()
@@ -82,13 +82,13 @@ class StackClusterTests: QuickSpec {
                     let vc = stack(with: children, meta: config)
                     expect(vc).to(haveValidSnapshot())
                 }
-
+                
                 it("should respect the backgroundColor config") {
                     let config = ClusterLayout.StackConfig(backgroundColor: UIColor.lightGray)
                     let vc = stack(with: children, meta: config)
                     expect(vc).to(haveValidSnapshot())
                 }
-
+                
                 it("should load config from a dictionary") {
                     let config: [String: Any] = [
                         "title": "Foo",
@@ -113,14 +113,14 @@ class StackClusterTests: QuickSpec {
                     labelComponent(title: "2", color: .red, labelSize: size),
                     labelComponent(title: "3", color: .red, labelSize: size),
                     labelComponent(title: "4", color: .red, labelSize: size)
-                    ]
-
+                ]
+                
                 it("should be able to scroll horizontally") {
                     let meta = ClusterLayout.StackConfig(axis: .horizontal)
                     let vc = stack(with: children, meta: meta)
                     vc?.loadViewIfNeeded()
                     let scrollView = vc?.stackView.superview as? UIScrollView
-
+                    
                     expect(vc).to(haveValidSnapshot())
                     expect(scrollView).to(scroll(.horizontal))
                     expect(scrollView).toNot(scroll(.vertical))
@@ -130,41 +130,41 @@ class StackClusterTests: QuickSpec {
                     let vc = stack(with: children)
                     vc?.loadViewIfNeeded()
                     let scrollView = vc?.stackView.superview as? UIScrollView
-
+                    
                     expect(vc).to(haveValidSnapshot())
                     expect(scrollView).to(scroll(.vertical))
                     expect(scrollView).toNot(scroll(.horizontal))
                 }
-
+                
                 context("when a horizontal stack is contained in a vertical stack") {
-
+                    
                     let nestedStack: () -> StackViewController? = {
                         let horizontal = ClusterLayout.StackConfig(axis: .horizontal)
                         let vertical = ClusterLayout.StackConfig(axis: .vertical)
-
+                        
                         return stack(
                             with: [ClusterLayout.stack(children: children, meta: horizontal)],
                             meta: vertical
                         )
                     }
-
+                    
                     it("should not cause the parent stack to overflow horizontally") {
                         let vc = nestedStack()
                         vc?.loadViewIfNeeded()
-
+                        
                         let scrollView = vc?.stackView.superview as? UIScrollView
-
+                        
                         expect(vc).to(haveValidSnapshot())
                         expect(scrollView).toNot(scroll(.horizontal))
                     }
-
+                    
                     it("should be able to scroll horizontally") {
                         let vc = nestedStack()
                         vc?.loadViewIfNeeded()
-
+                        
                         let horizontalStack = vc?.childViewControllers.first as? StackViewController
                         let scrollView2 = horizontalStack?.stackView.superview as? UIScrollView
-
+                        
                         expect(vc).to(haveValidSnapshot())
                         expect(scrollView2).to(scroll(.horizontal))
                     }
@@ -189,7 +189,7 @@ class StackClusterTests: QuickSpec {
                 let fixedSizeChildren = (1...4).map {
                     labelComponent(title: String($0), color: .red, labelSize: size)
                 }
-
+                
                 let nest = [
                     ClusterLayout.stack(children: children, meta: meta),
                     ClusterLayout.stack(children: fixedSizeChildren, meta: horizontalMeta),
@@ -278,7 +278,7 @@ private func stack(with children: [Component], meta: ComponentMeta? = nil) -> St
 }
 
 func stackViewController(with child: UIViewController) -> UIViewController? {
-    let component = Component.view(builder: { _ in child }, meta: nil)
+    let component = Component.single(viewBuilder: { _ in child }, meta: nil)
     return ClusterLayout.stack(children: [component], meta: nil).viewController()
 }
 
@@ -286,7 +286,7 @@ private func labelComponent(title: String?,
                             color: UIColor? = nil,
                             labelSize: CGSize? = nil) -> Component {
     
-    let builder: Component.ViewBuilder = { meta in
+    let builder: Component.SingleViewBuilder = { meta in
         let vc = UIViewController()
         vc.view.backgroundColor = color
         let label = UILabel()
@@ -303,8 +303,8 @@ private func labelComponent(title: String?,
         return vc
     }
     
-    return Component.view(
-        builder: builder,
+    return Component.single(
+        viewBuilder: builder,
         meta: title.map { ["title": $0] }
     )
 }

--- a/Tests/TabBarClusterTests.swift
+++ b/Tests/TabBarClusterTests.swift
@@ -23,7 +23,7 @@ class TabBarClusterTests: QuickSpec {
                 simpleComponent(meta: TabConfig(title: "test1"), color: .red),
                 simpleComponent(meta: TabConfig(title: "test2"), color: .blue),
                 simpleComponent(meta: TabConfig(title: "test3"), color: .orange)
-                ]
+            ]
             
             it("should display its children") {
                 let children: [Component] = [
@@ -43,7 +43,7 @@ class TabBarClusterTests: QuickSpec {
             context("when meta represents the selected index") {
                 
                 typealias TabBarConfig = ClusterLayout.TabBarConfig
-
+                
                 it("should consider it and select the proper tab") {
                     let meta = TabBarConfig(selectedIndex: 1)
                     let vc = ClusterLayout.tabBar(children: children, meta: meta).viewController()
@@ -83,9 +83,9 @@ class TabBarClusterTests: QuickSpec {
             
             it("should ignore children without view") {
                 let children: [Component] = [
-                    Component.view(builder: { _ in nil }, meta: TabConfig(title: "_")),
+                    Component.single(viewBuilder: { _ in nil }, meta: TabConfig(title: "_")),
                     simpleComponent(meta: TabConfig(title: "test1"), color: .red)
-                    ]
+                ]
                 let vc = ClusterLayout.tabBar(children: children, meta: nil).viewController()
                 expectTabCount(vc) == 1
                 expect(vc).to(haveValidSnapshot())
@@ -99,7 +99,7 @@ class TabBarClusterTests: QuickSpec {
                     let children: [Component] = [
                         simpleComponent(meta: nil),
                         validComponent
-                        ]
+                    ]
                     let vc = ClusterLayout.tabBar(children: children, meta: nil).viewController()
                     expectTabCount(vc) == 1
                     expect(vc).to(haveValidSnapshot())
@@ -110,7 +110,7 @@ class TabBarClusterTests: QuickSpec {
                     let children: [Component] = [
                         simpleComponent(meta: ["title": "test", "icon_name": "checkmark"]),
                         validComponent
-                        ]
+                    ]
                     let vc = ClusterLayout.tabBar(children: children,
                                                   meta: nil,
                                                   bundle: bundle).viewController()
@@ -122,7 +122,7 @@ class TabBarClusterTests: QuickSpec {
                     let children: [Component] = [
                         simpleComponent(meta: ["icon_name": "_"]),
                         validComponent
-                        ]
+                    ]
                     let vc = ClusterLayout.tabBar(children: children, meta: nil).viewController()
                     expectTabCount(vc) == 1
                     expect(vc).to(haveValidSnapshot())
@@ -132,7 +132,7 @@ class TabBarClusterTests: QuickSpec {
                     let children: [Component] = [
                         simpleComponent(meta: ["title": "_"]),
                         validComponent
-                        ]
+                    ]
                     let vc = ClusterLayout.tabBar(children: children, meta: nil).viewController()
                     expectTabCount(vc) == 1
                     expect(vc).to(haveValidSnapshot())
@@ -152,14 +152,14 @@ private func expectTabCount(_ viewController: UIViewController?,
 }
 
 private func simpleComponent(meta: ComponentMeta?, color: UIColor? = nil) -> Component {
-    let builder: Component.ViewBuilder = { meta in
+    let builder: Component.SingleViewBuilder = { meta in
         let vc = UIViewController()
         vc.view.backgroundColor = color
         return vc
     }
     
-    return Component.view(builder: builder,
-                          meta: meta)
+    return Component.single(viewBuilder: builder,
+                            meta: meta)
 }
 
 private typealias TabConfig = ClusterLayout.TabConfig

--- a/Tests/TabBarClusterTests.swift
+++ b/Tests/TabBarClusterTests.swift
@@ -152,13 +152,13 @@ private func expectTabCount(_ viewController: UIViewController?,
 }
 
 private func simpleComponent(meta: ComponentMeta?, color: UIColor? = nil) -> Component {
-    let builder: Component.SingleViewBuilder = { meta in
+    let viewBuilder: Component.SingleViewBuilder = { meta in
         let vc = UIViewController()
         vc.view.backgroundColor = color
         return vc
     }
     
-    return Component.single(viewBuilder: builder,
+    return Component.single(viewBuilder: viewBuilder,
                             meta: meta)
 }
 


### PR DESCRIPTION
Here's my suggestion on how to disambiguate the use of the term "view":
- The `.view` enum case has been renamed to `.single`.
- Function types that return `Component`s are now called "builders" for short.
- Function types that return `UIViewController`s are called "view builders".

Also:
- Matched up property and variable names with the names of their types.
- Renamed (`JSONFactory`'s) factory methods according to Swift API Design Guidelines.