### PR TITLE
Control Navigation Bar visibility

### DIFF
--- a/Documentation/JSON schema guide.md
+++ b/Documentation/JSON schema guide.md
@@ -41,12 +41,13 @@ All mandatory fields should be present, otherwise the TabBar `Component` won't b
 
 ### Tab meta schema
 
-All mandatory fields should be present, otherwise the Tab `Component` won't be build and thus not added to the TabBar `Component`.
+`title` and `icon_name` are mandatory fields and must be present, otherwise the Tab `Component` won't be build and thus not added to the TabBar `Component`.
 
 | Key | Type | Description | Maps to | Optional | Default value |
 | --- | ---- | ----------- | ------- | -------- | ------------- |
 | `title` | `String` | The title to display on the tab. | `title` | No | . |
 | `icon_name` | `Int` | The name of the icon to display on the tab. | `iconName` | No | . |
+| `show_nav_bar` | `Bool` | `True` if the top navigation bar should be displayed and controlled by the Tab component, `false` otherwise. | `showNavBar` | Yes | `true` |
 
 ### StackConfig meta schema
 


### PR DESCRIPTION
At the moment the navigation bar is controlled by the `navigation` component. Whilst this works great most of the time, we also have some special use cases where want to hide the navigation bar or let another component control it.

This PR adds a `show_nav_bar` meta attribute to the documentation. Implementation is missing :)